### PR TITLE
Fix problem when loading the txt files on windows

### DIFF
--- a/autocorrect/utils.py
+++ b/autocorrect/utils.py
@@ -23,7 +23,7 @@ RE = '[A-Za-z]+'
 def words_from_archive(filename, include_dups=False, map_case=False):
     """extract words from a text file in the archive"""
     bz2 = os.path.join(PATH, BZ2)
-    tar_path = os.path.join('words', filename)
+    tar_path = 'words/'+filename #fix loading problem on windows os.path.join('words', filename)
     with closing(tarfile.open(bz2, 'r:bz2')) as t:
         with closing(t.extractfile(tar_path)) as f:
             words = re.findall(RE, f.read().decode(encoding='utf-8'))

--- a/autocorrect/utils.py
+++ b/autocorrect/utils.py
@@ -23,7 +23,7 @@ RE = '[A-Za-z]+'
 def words_from_archive(filename, include_dups=False, map_case=False):
     """extract words from a text file in the archive"""
     bz2 = os.path.join(PATH, BZ2)
-    tar_path = 'words/'+filename #fix loading problem on windows os.path.join('words', filename)
+    tar_path = '{}/{}'.format('words', filename)
     with closing(tarfile.open(bz2, 'r:bz2')) as t:
         with closing(t.extractfile(tar_path)) as f:
             words = re.findall(RE, f.read().decode(encoding='utf-8'))

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(name='autocorrect',
-      version='0.2.0',
+      version='0.3.0',
       packages=['autocorrect'],
       package_data={'autocorrect': ['words.bz2']},
       description='Python 3 Spelling Corrector',


### PR DESCRIPTION
os.path.join('words', filename) created a windows like address while the tarfile package uses linux like file addresses
The change has been tested on Ubuntu as well 